### PR TITLE
test: add common test utilities and improve test infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,53 +1,127 @@
-# Rust
-/target/
-**/*.rs.bk
-*.pdb
+# Dependencies
+node_modules/
+.pnpm-store/
+vendor/
+venv/
+env/
+.env
+*.egg-info/
+dist/
+build/
 
-# Cargo
-Cargo.lock
-
-# IDE
+# IDE and editor files
 .idea/
 .vscode/
 *.swp
 *.swo
 *~
-
-# OS
 .DS_Store
-Thumbs.db
 
-# Environment
-.env
-.env.local
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
 
 # Testing
-*.profraw
-*.profdata
+coverage/
+.coverage
+.pytest_cache/
+.phpunit.result.cache
 
-# Coverage
-tarpaulin-report.html
-cobertura.xml
+# Production builds
+dist/
+build/
+out/
+.next/
+.nuxt/
+.cache/
 
-# Debug
-*.dSYM/
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Ruby
+*.gem
+.bundle/
+Gemfile.lock
+
+# Rust
+target/
+Cargo.lock
+
+# Go
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Database
+*.sqlite
+*.sqlite3
+*.db
+
+# OS files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Claude Code specific
+.claude/settings.local.json
+CLAUDE.local.md
 
 # Temporary files
 *.tmp
 *.temp
-
-# Logs
-*.log
-
-# Task Master
-.taskmaster/
-
-# Test files
-test-temp/
+.tmp/
+.temp/
 
 # Backup files
 *.bak
+*.backup
+*~
+
+logs
+dev-debug.log
+# Dependency directories
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+# OS specific
+
+# Task files
+.taskmaster/
+# tasks.json
+# tasks/
 
 # Claude
 notes/
-scripts/
+
+# Test fixtures
+test-fixtures/

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,4 @@
 {
-  "MD013": false
+  "MD013": false,
+  "MD040": false
 }

--- a/.taskmaster/config.json
+++ b/.taskmaster/config.json
@@ -1,4 +1,13 @@
 {
+  "global": {
+    "logLevel": "info",
+    "debug": false,
+    "defaultSubtasks": 5,
+    "defaultPriority": "medium",
+    "defaultTag": "master",
+    "projectName": "just-mcp",
+    "responseLanguage": "English"
+  },
   "models": {
     "main": {
       "provider": "claude-code",
@@ -19,31 +28,22 @@
       "temperature": 0.2
     }
   },
-  "global": {
-    "logLevel": "info",
-    "debug": false,
-    "defaultNumTasks": 10,
-    "defaultSubtasks": 5,
-    "defaultPriority": "medium",
-    "projectName": "just-mcp",
-    "ollamaBaseURL": "http://localhost:11434/api",
-    "bedrockBaseURL": "https://bedrock.us-east-1.amazonaws.com",
-    "responseLanguage": "English",
-    "defaultTag": "master",
-    "userId": "1234567890"
-  },
   "claudeCode": {
     "maxTurns": 5,
     "appendSystemPrompt": "Always follow coding best practices and use the tools provided to you",
     "permissionMode": "default",
-    "allowedTools": [
-      "Read",
-      "LS"
-    ],
-    "disallowedTools": [
-      "Write",
-      "Edit"
-    ],
+    "allowedTools": ["Read", "LS"],
+    "disallowedTools": ["Write", "Edit"],
     "mcpServers": {}
+  },
+  "commandSpecific": {
+    "parse-prd": {
+      "maxTurns": 10,
+      "customSystemPrompt": "You are a task breakdown specialist"
+    },
+    "analyze-complexity": {
+      "maxTurns": 3,
+      "appendSystemPrompt": "Focus on identifying bottlenecks and optimize for parallelization"
+    }
   }
 }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,7 +32,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@onegrep.dev. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <conduct@onegrep.dev>. All complaints will be reviewed and investigated promptly and fairly.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ just build-release # Release build
 ### Branch Naming
 
 Use descriptive branch names:
+
 - `feature/add-xyz-support`
 - `fix/issue-123-description`
 - `docs/update-readme`
@@ -54,6 +55,7 @@ Use descriptive branch names:
 ### Development Workflow
 
 1. **Create a new branch**:
+
    ```bash
    git checkout -b feature/your-feature-name
    ```
@@ -61,11 +63,13 @@ Use descriptive branch names:
 2. **Make your changes** following the coding standards
 
 3. **Run tests and checks**:
+
    ```bash
    just check  # Runs format, lint, and test
    ```
 
 4. **Commit your changes**:
+
    ```bash
    git add .
    git commit -m "feat: add support for XYZ"

--- a/README.md
+++ b/README.md
@@ -25,30 +25,35 @@ This enables AI assistants to understand, explore, and execute a project's commo
 ## Features
 
 ### 🔍 **Intelligent Justfile Discovery**
+
 - Real-time monitoring with filesystem watching
 - Multi-project support with optional naming (`--watch-dir path:name`)
 - Dynamic tool generation from justfile tasks
 - Hot reloading on justfile modifications
 
 ### 📝 **Comprehensive Justfile Parsing**
+
 - Full syntax support: parameters, defaults, dependencies, comments, attributes
 - Parameter documentation from `# {{param}}: description` comments
 - Multiple parameter formats: `task(param)` and `task param`
 - Doc attributes: `[doc("description")]` for enhanced documentation
 
 ### 🛡️ **Security & Resource Management**
+
 - Input validation prevents command injection and path traversal
 - Configurable timeouts, memory limits, and output size controls
 - Directory whitelisting and parameter sanitization
 - Shell escaping and strict validation modes
 
 ### ⚙️ **Administrative Tools**
+
 - `admin_sync`: Manual justfile re-scanning and registry refresh
 - `admin_create_task`: AI-assisted task creation with automatic backup
 - Conflict prevention and task name validation
 - Multi-directory targeting for task creation
 
 ### 🚀 **MCP Protocol Compliance**
+
 - Full JSON-RPC 2.0 MCP specification implementation
 - Real-time tool list updates via notifications
 - Standard capabilities: `tools/list`, `tools/call`, change notifications
@@ -138,6 +143,7 @@ Add to your MCP settings file (e.g., `~/.config/mcp/settings.json`):
 ### Tool Naming Convention
 
 Tools are exposed with the format:
+
 - Single directory: `just_<task>`
 - Named directories: `just_<task>@<name>`
 - Multiple unnamed directories: `just_<task>_<full_path>`
@@ -160,6 +166,7 @@ test coverage="false":
 The AI assistant can:
 
 1. **Discover available tools**:
+
    ```json
    {
      "method": "tools/list",
@@ -184,6 +191,7 @@ The AI assistant can:
    ```
 
 2. **Execute tasks**:
+
    ```json
    {
      "method": "tools/call",
@@ -199,6 +207,7 @@ The AI assistant can:
 ### Administrative Commands
 
 **Sync justfiles** (refresh tool registry):
+
 ```json
 {
   "method": "tools/call",
@@ -209,6 +218,7 @@ The AI assistant can:
 ```
 
 **Create new task** with AI assistance:
+
 ```json
 {
   "method": "tools/call",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,81 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Base directory for test assets and fixtures
+pub const TEST_BASE_DIR: &str = "test-fixtures";
+
+/// Creates a test directory under the base test directory
+///
+/// # Arguments
+/// * `test_name` - Name of the test subdirectory to create
+///
+/// # Returns
+/// * `PathBuf` - Path to the created test directory
+///
+/// # Panics
+/// * If directory creation fails
+pub fn create_test_dir(test_name: &str) -> PathBuf {
+    let test_dir = Path::new(TEST_BASE_DIR).join(test_name);
+    fs::create_dir_all(&test_dir).expect(&format!(
+        "Failed to create test directory: {}",
+        test_dir.display()
+    ));
+    test_dir
+}
+
+/// Creates a test directory and returns both the directory path and a justfile path within it
+///
+/// # Arguments
+/// * `test_name` - Name of the test subdirectory to create
+///
+/// # Returns
+/// * `(PathBuf, PathBuf)` - Tuple of (test_dir, justfile_path)
+pub fn create_test_dir_with_justfile(test_name: &str) -> (PathBuf, PathBuf) {
+    let test_dir = create_test_dir(test_name);
+    let justfile_path = test_dir.join("justfile");
+    (test_dir, justfile_path)
+}
+
+/// Cleans up a test directory (removes it and all contents)
+///
+/// # Arguments
+/// * `test_name` - Name of the test subdirectory to remove
+pub fn cleanup_test_dir(test_name: &str) {
+    let test_dir = Path::new(TEST_BASE_DIR).join(test_name);
+    if test_dir.exists() {
+        fs::remove_dir_all(&test_dir).expect(&format!(
+            "Failed to remove test directory: {}",
+            test_dir.display()
+        ));
+    }
+}
+
+/// Gets the path to a test directory without creating it
+///
+/// # Arguments
+/// * `test_name` - Name of the test subdirectory
+///
+/// # Returns
+/// * `PathBuf` - Path to the test directory
+#[allow(dead_code)]
+pub fn get_test_dir_path(test_name: &str) -> PathBuf {
+    Path::new(TEST_BASE_DIR).join(test_name)
+}
+
+/// Creates a test justfile with the given content
+///
+/// # Arguments
+/// * `test_name` - Name of the test subdirectory
+/// * `content` - Content to write to the justfile
+///
+/// # Returns
+/// * `PathBuf` - Path to the created justfile
+#[allow(dead_code)]
+pub fn create_test_justfile(test_name: &str, content: &str) -> PathBuf {
+    let (_, justfile_path) = create_test_dir_with_justfile(test_name);
+    fs::write(&justfile_path, content).expect(&format!(
+        "Failed to write justfile: {}",
+        justfile_path.display()
+    ));
+    justfile_path
+}

--- a/tests/notification_test.rs
+++ b/tests/notification_test.rs
@@ -1,16 +1,17 @@
 use just_mcp::registry::ToolRegistry;
 use just_mcp::watcher::JustfileWatcher;
 use std::fs;
-use std::path::Path;
+
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+mod common;
+use common::{cleanup_test_dir, create_test_dir_with_justfile};
+
 #[tokio::test]
 async fn test_watcher_updates_registry_on_change() {
-    // Use test-temp directory
-    let test_dir = Path::new("test-temp/watcher_notification_test");
-    fs::create_dir_all(test_dir).unwrap();
-    let justfile_path = test_dir.join("justfile");
+    // Use test fixtures directory
+    let (_test_dir, justfile_path) = create_test_dir_with_justfile("watcher_notification_test");
 
     // Create registry and watcher
     let registry = Arc::new(Mutex::new(ToolRegistry::new()));
@@ -92,6 +93,9 @@ build:
             "Expected empty registry after parsing empty justfile"
         );
     }
+
+    // Cleanup
+    cleanup_test_dir("watcher_notification_test");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Add reusable test utilities in `tests/common/mod.rs` for better test organization
- Update integration tests to use the new common utilities
- Expand `.gitignore` to be more comprehensive

## Changes
- **Test Infrastructure**: Created `tests/common/mod.rs` with helper functions for test directory management
- **Integration Tests**: Updated `executor_integration_test.rs` and `notification_test.rs` to use common utilities
- **Gitignore**: Expanded to cover multiple languages and frameworks (Python, Ruby, Go, Node.js, etc.)
- **Documentation**: Minor updates to README, CODE_OF_CONDUCT, and CONTRIBUTING
- **Configuration**: Updated `.taskmaster/config.json` and `.markdownlint.json`

🤖 Generated with [Claude Code](https://claude.ai/code)