### PR TITLE
fix(build): resolve cross-compilation issues for zigbuild releases

### DIFF
--- a/.github/workflows/release-zigbuild.yml
+++ b/.github/workflows/release-zigbuild.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Build with zigbuild
         run: |
           source $HOME/.cargo/env
+          # Enable assertions for C code (required by tree-sitter-just)
+          export CFLAGS="-UNDEBUG"
+          export CXXFLAGS="-UNDEBUG"
           cargo zigbuild --release --target ${{ matrix.target }}
 
       - name: Prepare artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ release-artifacts/
 
 # Build output directory
 build/
+
+# Zigbuild Release
+.intentionally-empty-file.o
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ndarray = { version = "0.16", optional = true }
 sqlite-vss = { version = "0.1", optional = true, features = ["download-libs"] }
 
 # HTTP client for embedding providers
-reqwest = { version = "0.12", features = ["json"], optional = true }
+reqwest = { version = "0.12", features = ["json", "native-tls-vendored"], optional = true }
 
 # Local embedding model support with Candle
 candle-core = { version = "0.8", optional = true }
@@ -80,6 +80,10 @@ streaming-iterator = { version = "0.1", optional = true }
 
 # ultrafast-mcp integration for framework-based MCP server
 ultrafast-mcp = { version = "202506018.1.0", features = ["core"], optional = true }
+
+# OpenSSL with vendored feature for cross-compilation support
+[target.'cfg(all())'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
 
 [dev-dependencies]
 mockall = "0.13"

--- a/just/release.just
+++ b/just/release.just
@@ -114,6 +114,9 @@ zigbuild-release version="v0.1.0":
     docker run --rm -v $(pwd):/io -w /io ghcr.io/rust-cross/cargo-zigbuild:latest \
         bash -c '
             set -euo pipefail
+            # Enable assertions for C code (required by tree-sitter-just)
+            export CFLAGS="-UNDEBUG"
+            export CXXFLAGS="-UNDEBUG"
             echo "📦 Adding Rust targets..." && \
             rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin && \
             echo "🔨 Building Linux x86_64..." && \
@@ -146,7 +149,7 @@ zigbuild-test target="x86_64-apple-darwin":
     
     echo "🧪 Testing cargo-zigbuild for {{target}}..."
     docker run --rm -v $(pwd):/io -w /io ghcr.io/rust-cross/cargo-zigbuild:latest \
-        bash -c "set -euo pipefail && rustup target add {{target}} && cargo zigbuild --release --target {{target}}"
+        bash -c "set -euo pipefail && export CFLAGS='-UNDEBUG' && export CXXFLAGS='-UNDEBUG' && rustup target add {{target}} && cargo zigbuild --release --target {{target}}"
     
     just _success "Build successful! Binary at: target/{{target}}/release/just-mcp"
 
@@ -163,7 +166,7 @@ zigbuild-target target version="v0.1.0":
     
     echo "🔨 Building {{target}} release using cargo-zigbuild..."
     docker run --rm -v $(pwd):/io -w /io ghcr.io/rust-cross/cargo-zigbuild:latest \
-        bash -c "set -euo pipefail && rustup target add {{target}} && cargo zigbuild --release --target {{target}}"
+        bash -c "set -euo pipefail && export CFLAGS='-UNDEBUG' && export CXXFLAGS='-UNDEBUG' && rustup target add {{target}} && cargo zigbuild --release --target {{target}}"
     
     echo "📦 Packaging {{target}} release artifact..."
     just _package_single_target "{{target}}" "{{version}}"


### PR DESCRIPTION
## Summary

This PR fixes critical cross-compilation issues that were preventing the zigbuild release process from working correctly.

## Problem

The release builds were failing due to two issues:
1. **OpenSSL dependency errors** - Cross-compilation couldn't find system OpenSSL libraries
2. **tree-sitter-just assertion requirement** - The C scanner requires assertions to be enabled even in release mode

## Solution

### OpenSSL Fix
- Added vendored OpenSSL support via `native-tls-vendored` feature in reqwest
- Added explicit openssl dependency with `vendored` feature
- This compiles OpenSSL from source instead of requiring system libraries

### tree-sitter-just Fix  
- Added `CFLAGS="-UNDEBUG"` to all build commands
- This keeps assertions enabled in C code while maintaining Rust release optimizations
- Applied to GitHub Actions workflow and justfile release commands

## Testing

The release process can now be tested locally:
```bash
just release v0.2.0 zigbuild
# or test a single platform
just zigbuild-test x86_64-unknown-linux-gnu
```

## Files Changed

- `.github/workflows/release-zigbuild.yml` - Added CFLAGS for assertions
- `Cargo.toml` - Added vendored OpenSSL dependencies
- `just/release.just` - Updated all zigbuild commands with CFLAGS
- `.gitignore` - Added zigbuild artifacts

These changes ensure the release process works reliably across all platforms without requiring specific system dependencies.